### PR TITLE
在route策略增加EnableHeadersAuthorization配置，用于开启key-auth认证

### DIFF
--- a/demo/consumer-variables/config.json
+++ b/demo/consumer-variables/config.json
@@ -42,6 +42,7 @@
               "Type": "Prefix",
               "Path": "/"
             },
+            "EnableHeadersAuthorization": true,
             "BackendService": {
               "backendService1": 100
             }
@@ -53,6 +54,7 @@
       "*": {
         "Matches": [
           {
+            "EnableHeadersAuthorization": true,
             "ServerRoot": "www1"
           }
         ]


### PR DESCRIPTION
在route策略增加EnableHeadersAuthorization配置，用于开启key-auth认证 