### PR TITLE
增加 sr-auth.js 模块，用于子请求认证方式（发送请求到acl服务认证）

### DIFF
--- a/pjs/http/sr-auth.js
+++ b/pjs/http/sr-auth.js
@@ -94,9 +94,13 @@
   _response: null,
 })
 
+.import({
+  __route: 'route',
+})
+
 .pipeline()
 .branch(
-  () => (_addr = config?.Configs?.PjOpenApiAuthAddr), (
+  () => __route?.config?.EnableSubrequestAuthorization && (_addr = config?.Configs?.SubrequestAuthAddr), (
     $=>$
     .handleMessageStart(
       msg => (

--- a/pjs/samples/sr-auth/config.json
+++ b/pjs/samples/sr-auth/config.json
@@ -1,0 +1,147 @@
+{
+  "Configs": {
+    "EnableDebug": true,
+    "SubrequestAuthAddr": "127.0.0.1:4040"
+  },
+  "Listeners": [
+    {
+      "Protocol": "HTTP",
+      "Port": 8080
+    },
+    {
+      "Protocol": "HTTP",
+      "Port": 8081
+    },
+    {
+      "Protocol": "HTTP",
+      "Port": 8082
+    }
+  ],
+  "RouteRules": {
+    "8080": {
+      "*": {
+        "RouteType": "HTTP",
+        "Matches": [
+          {
+            "Path": {
+              "Type": "Prefix",
+              "Path": "/"
+            },
+            "EnableSubrequestAuthorization": true,
+            "BackendService": {
+              "backendService1": 100
+            }
+          }
+        ]
+      }
+    },
+    "8081": {
+      "*": {
+        "Matches": [
+          {
+            "ServerRoot": "/var/www/html",
+            "Index": [
+              "index.html",
+              "index.htm"
+            ],
+            "TryFiles": [
+              "$uri",
+              "$uri/default/",
+              "=404"
+            ]
+          }
+        ]
+      }
+    },
+    "8082": {
+      "*": {
+        "Matches": [
+          {
+            "ServerRoot": "www2",
+            "Index": [
+              "default.html",
+              "index.htm"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "Services": {
+    "backendService1": {
+      "StickyCookieName": "_srv_id",
+      "StickyCookieExpires": 3600,
+      "Endpoints": {
+        "127.0.0.1:8081": {
+          "Weight": 50
+        },
+        "127.0.0.1:8082": {
+          "Weight": 50
+        }
+      }
+    }
+  },
+  "Chains": {
+    "HTTPRoute": [
+      "common/access-control.js",
+      "common/ratelimit.js",
+      "common/consumer.js",
+      "http/codec.js",
+      "http/auth.js",
+      "http/route.js",
+      "http/sr-auth.js",
+      "http/service.js",
+      "http/metrics.js",
+      "http/tracing.js",
+      "http/logging.js",
+      "http/circuit-breaker.js",
+      "http/throttle-domain.js",
+      "http/throttle-route.js",
+      "filter/request-redirect.js",
+      "filter/header-modifier.js",
+      "filter/url-rewrite.js",
+      "http/forward.js",
+      "http/default.js"
+    ],
+    "HTTPSRoute": [
+      "common/access-control.js",
+      "common/ratelimit.js",
+      "common/tls-termination.js",
+      "common/consumer.js",
+      "http/codec.js",
+      "http/auth.js",
+      "http/route.js",
+      "http/sr-auth.js",
+      "http/service.js",
+      "http/metrics.js",
+      "http/tracing.js",
+      "http/logging.js",
+      "http/circuit-breaker.js",
+      "http/throttle-domain.js",
+      "http/throttle-route.js",
+      "filter/request-redirect.js",
+      "filter/header-modifier.js",
+      "filter/url-rewrite.js",
+      "http/forward.js",
+      "http/default.js"
+    ],
+    "TLSPassthrough": [
+      "common/access-control.js",
+      "common/ratelimit.js",
+      "tls/passthrough.js",
+      "common/consumer.js"
+    ],
+    "TLSTerminate": [
+      "common/access-control.js",
+      "common/ratelimit.js",
+      "common/tls-termination.js",
+      "common/consumer.js",
+      "tls/forward.js"
+    ],
+    "TCPRoute": [
+      "common/access-control.js",
+      "common/ratelimit.js",
+      "tcp/forward.js"
+    ]
+  }
+}


### PR DESCRIPTION
增加 sr-auth.js 模块，用于子请求认证方式（发送请求到acl服务认证）