### PR TITLE
sr-auth.js 支持authorization以或不以bearer开头

### DIFF
--- a/pjs/http/sr-auth.js
+++ b/pjs/http/sr-auth.js
@@ -52,8 +52,12 @@
       cookies,
       jwt,
     ) => (
-      (bearer?.startsWith?.('Bearer ') || bearer?.startsWith?.('bearer ')) ? (
-        jwt = bearer.substring(7)
+      bearer ? (
+        (bearer?.startsWith?.('Bearer ') || bearer?.startsWith?.('bearer ')) ? (
+          jwt = bearer.substring(7)
+        ) : (
+          jwt = bearer
+        )
       ) : (
         (args = getArgs(head?.path?.split?.('?')?.[1])) && (
           jwt = args['jwt']


### PR DESCRIPTION
sr-auth.js 支持authorization以或不以bearer开头, 参考：pjs/samples/sr-auth/config.json