### PR TITLE
fix wrong field name and hostname process logic

### DIFF
--- a/pjs/filter/url-rewrite.js
+++ b/pjs/filter/url-rewrite.js
@@ -65,9 +65,9 @@
   makeRewriteHandler = (path, cfg) => (
     (
       handlers = (cfg?.Filters || []).filter(
-        e => e?.Type === 'URLRewrite'
+        e => e?.type === 'URLRewrite'
       ).map(
-        e => makeHeadHandler(path, e)
+        e => makeHeadHandler(path, e.urlRewrite)
       ).filter(
         e => e
       )

--- a/pjs/filter/url-rewrite.js
+++ b/pjs/filter/url-rewrite.js
@@ -58,6 +58,10 @@
             )
           )()
         )
+      ) : cfg?.hostname ? (
+        head => head.headers && (
+          head.headers.host = cfg.hostname
+        )
       ) : null
     )
   ),


### PR DESCRIPTION
- In configuration, there field name is `type` instead of `Type`.
- `hostname` is a individual field not related with path match type.