### PR TITLE
[fix] ProxyPreserveHost did not set __host

### DIFF
--- a/pjs/http/forward.js
+++ b/pjs/http/forward.js
@@ -253,8 +253,10 @@
       ) => (
         (__host = attrs?.Host) ? (
           msg.head.headers.host = __host
-        ) : !proxyPreserveHostCache.get(__route) && (
+        ) : !proxyPreserveHostCache.get(__route) ? (
           msg.head.headers.host = __target
+        ) : (
+          __host = msg.head.headers.host
         ),
         attrs?.UpstreamCert ? (
           __cert = attrs?.UpstreamCert


### PR DESCRIPTION
When set `ProxyPreserveHost` to `true`, in `http/forword.js` it forgot to set `__host` variable, and the `sni` option of `connectTLS` filter in `lib/connect-tls.js` will be empty, connecting to the TLS backend will be failed.